### PR TITLE
Added User Print - A "light" console out option

### DIFF
--- a/keyboards/planck/keymaps/pvc/Makefile
+++ b/keyboards/planck/keymaps/pvc/Makefile
@@ -6,7 +6,7 @@
 BOOTMAGIC_ENABLE = no  # Virtual DIP switch configuration(+1000)
 MOUSEKEY_ENABLE  = yes # Mouse keys(+4700)
 EXTRAKEY_ENABLE  = yes # Audio control and System control(+450)
-CONSOLE_ENABLE   = no  # Console for debug(+400)
+CONSOLE_ENABLE   = yes # Console for debug(+400)
 COMMAND_ENABLE   = yes # Commands for debug and configuration
 NKRO_ENABLE      = yes # Nkey Rollover - if this doesn't work, see here: https://github.com/tmk/tmk_keyboard/wiki/FAQ#nkro-doesnt-work
 BACKLIGHT_ENABLE = yes # Enable keyboard backlight functionality

--- a/keyboards/planck/keymaps/pvc/config.h
+++ b/keyboards/planck/keymaps/pvc/config.h
@@ -68,10 +68,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 /* disable debug print */
-//#define NO_DEBUG
+#ifndef NO_DEBUG
+#  define NO_DEBUG
+#endif
 
 /* disable print */
-//#define NO_PRINT
+// #ifndef NO_PRINT
+// #  define NO_PRINT
+// #endif
+
+/* Only print user print statements */
+#define USER_PRINT
+
 
 /* disable action features */
 //#define NO_ACTION_LAYER

--- a/tmk_core/common/avr/xprintf.h
+++ b/tmk_core/common/avr/xprintf.h
@@ -56,8 +56,8 @@ void xitoa(long value, char radix, char width);
 #define xfprintf(func, format, ...)     __xfprintf(func, PSTR(format), ##__VA_ARGS__)
 
 void __xprintf(const char *format_p, ...);	/* Send formatted string to the registered device */
-void __xsprintf(char*, const char *format_p, ...);	/* Put formatted string to the memory */
-void __xfprintf(void(*func)(uint8_t), const char *format_p, ...); /* Send formatted string to the specified device */
+// void __xsprintf(char*, const char *format_p, ...);	/* Put formatted string to the memory */
+// void __xfprintf(void(*func)(uint8_t), const char *format_p, ...); /* Send formatted string to the specified device */
 
 /* Format string is placed in the ROM. The format flags is similar to printf().
 
@@ -88,7 +88,7 @@ void __xfprintf(void(*func)(uint8_t), const char *format_p, ...); /* Send format
 /*-----------------------------------------------------------------------------*/
 char xatoi(char **str, long *ret);
 
-/* Get value of the numeral string. 
+/* Get value of the numeral string.
 
   str
     Pointer to pointer to source string

--- a/tmk_core/common/mbed/xprintf.cpp
+++ b/tmk_core/common/mbed/xprintf.cpp
@@ -7,7 +7,7 @@
 #define STRING_STACK_LIMIT    120
 
 //TODO
-int xprintf(const char* format, ...) { return 0; }
+int __xprintf(const char* format, ...) { return 0; }
 
 #if 0
 /* mbed Serial */

--- a/tmk_core/common/mbed/xprintf.h
+++ b/tmk_core/common/mbed/xprintf.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-int xprintf(const char *format, ...);
+int __xprintf(const char *format, ...);
 
 #ifdef __cplusplus
 }

--- a/tmk_core/common/print.h
+++ b/tmk_core/common/print.h
@@ -36,40 +36,140 @@
 
 #ifndef NO_PRINT
 
+#if defined(__AVR__) /* __AVR__ */
 
-#if defined(__AVR__)
+#  include "avr/xprintf.h"
 
-#include "avr/xprintf.h"
-#define print(s)    xputs(PSTR(s))
-#define println(s)  xputs(PSTR(s "\r\n"))
+#  ifdef USER_PRINT /* USER_PRINT */
 
-#ifdef __cplusplus
+// Remove normal print defines
+#    define print(s)
+#    define println(s)
+#    undef xprintf
+#    define xprintf(fmt, ...)
+
+// Create user print defines
+#    define uprint(s)          xputs(PSTR(s))
+#    define uprintln(s)        xputs(PSTR(s "\r\n"))
+#    define uprintf(fmt, ...)  __xprintf(PSTR(fmt), ##__VA_ARGS__)
+
+#  else /* NORMAL PRINT */
+
+// Create user & normal print defines
+#    define print(s)           xputs(PSTR(s))
+#    define println(s)         xputs(PSTR(s "\r\n"))
+#    define uprint(s)          print(s)
+#    define uprintln(s)        println(s)
+#    define uprintf(fmt, ...)  xprintf(fmt, ...)
+
+#  endif /* USER_PRINT / NORMAL PRINT */
+
+#  ifdef __cplusplus
 extern "C"
-#endif
+#  endif
+
 /* function pointer of sendchar to be used by print utility */
 void print_set_sendchar(int8_t (*print_sendchar_func)(uint8_t));
 
-#elif defined(PROTOCOL_CHIBIOS) /* __AVR__ */
+#elif defined(PROTOCOL_CHIBIOS) /* PROTOCOL_CHIBIOS */
 
-#include "chibios/printf.h"
+#  include "chibios/printf.h"
 
-#define print(s)    printf(s)
-#define println(s)  printf(s "\r\n")
-#define xprintf  printf
+#  ifdef USER_PRINT /* USER_PRINT */
 
-#elif defined(__arm__) /* __AVR__ */
+// Remove normal print defines
+#    define print(s)
+#    define println(s)
+#    define xprintf(fmt, ...)
 
-#include "mbed/xprintf.h"
+// Create user print defines
+#    define uprint(s)    printf(s)
+#    define uprintln(s)  printf(s "\r\n")
+#    define uprintf      printf
 
-#define print(s)    xprintf(s)
-#define println(s)  xprintf(s "\r\n")
+#  else /* NORMAL PRINT */
+
+// Create user & normal print defines
+#    define print(s)     printf(s)
+#    define println(s)   printf(s "\r\n")
+#    define xprintf      printf
+#    define uprint(s)    printf(s)
+#    define uprintln(s)  printf(s "\r\n")
+#    define uprintf      printf
+
+#  endif /* USER_PRINT / NORMAL PRINT */
+
+#elif defined(__arm__) /* __arm__ */
+
+#  include "mbed/xprintf.h"
+
+#  ifdef USER_PRINT /* USER_PRINT */
+
+// Remove normal print defines
+#    define print(s)
+#    define println(s)
+#    define xprintf(fmt, ...)
+
+// Create user print defines
+#    define uprintf(fmt, ...)  __xprintf(fmt, ...)
+#    define uprint(s)          xprintf(s)
+#    define uprintln(s)        xprintf(s "\r\n")
+
+#  else /* NORMAL PRINT */
+
+// Create user & normal print defines
+#    define xprintf(fmt, ...)  __xprintf(fmt, ...)
+#    define print(s)           xprintf(s)
+#    define println(s)         xprintf(s "\r\n")
+#    define uprint(s)          print(s)
+#    define uprintln(s)        println(s)
+#    define uprintf(fmt, ...)  xprintf(fmt, ...)
+
+#  endif /* USER_PRINT / NORMAL PRINT */
 
 /* TODO: to select output destinations: UART/USBSerial */
-#define print_set_sendchar(func)
+#  define print_set_sendchar(func)
 
-#endif /* __AVR__ */
+#endif /* __AVR__ / PROTOCOL_CHIBIOS / __arm__ */
 
+// User print disables the normal print messages in the body of QMK/TMK code and
+// is meant as a lightweight alternative to NOPRINT. Use it when you only want to do
+// a spot of debugging but lack flash resources for allowing all of the codebase to
+// print (and store their wasteful strings).
+//
+// !!! DO NOT USE USER PRINT CALLS IN THE BODY OF QMK/TMK !!!
+//
+#ifdef USER_PRINT
 
+// Disable normal print
+#define print_dec(data)
+#define print_decs(data)
+#define print_hex4(data)
+#define print_hex8(data)
+#define print_hex16(data)
+#define print_hex32(data)
+#define print_bin4(data)
+#define print_bin8(data)
+#define print_bin16(data)
+#define print_bin32(data)
+#define print_bin_reverse8(data)
+#define print_bin_reverse16(data)
+#define print_bin_reverse32(data)
+#define print_val_dec(v)
+#define print_val_decs(v)
+#define print_val_hex8(v)
+#define print_val_hex16(v)
+#define print_val_hex32(v)
+#define print_val_bin8(v)
+#define print_val_bin16(v)
+#define print_val_bin32(v)
+#define print_val_bin_reverse8(v)
+#define print_val_bin_reverse16(v)
+#define print_val_bin_reverse32(v)
+
+#else /* NORMAL_PRINT */
+
+//Enable normal print
 /* decimal */
 #define print_dec(i)                xprintf("%u", i)
 #define print_decs(i)               xprintf("%d", i)
@@ -98,6 +198,39 @@ void print_set_sendchar(int8_t (*print_sendchar_func)(uint8_t));
 #define print_val_bin_reverse8(v)   xprintf(#v ": %08b\n", bitrev(v))
 #define print_val_bin_reverse16(v)  xprintf(#v ": %016b\n", bitrev16(v))
 #define print_val_bin_reverse32(v)  xprintf(#v ": %032lb\n", bitrev32(v))
+
+#endif /* USER_PRINT / NORMAL_PRINT */
+
+// User Print
+
+/* decimal */
+#define uprint_dec(i)               uprintf("%u", i)
+#define uprint_decs(i)              uprintf("%d", i)
+/* hex */
+#define uprint_hex4(i)              uprintf("%X", i)
+#define uprint_hex8(i)              uprintf("%02X", i)
+#define uprint_hex16(i)             uprintf("%04X", i)
+#define uprint_hex32(i)             uprintf("%08lX", i)
+/* binary */
+#define uprint_bin4(i)              uprintf("%04b", i)
+#define uprint_bin8(i)              uprintf("%08b", i)
+#define uprint_bin16(i)             uprintf("%016b", i)
+#define uprint_bin32(i)             uprintf("%032lb", i)
+#define uprint_bin_reverse8(i)      uprintf("%08b", bitrev(i))
+#define uprint_bin_reverse16(i)     uprintf("%016b", bitrev16(i))
+#define uprint_bin_reverse32(i)     uprintf("%032lb", bitrev32(i))
+/* print value utility */
+#define uprint_val_dec(v)           uprintf(#v ": %u\n", v)
+#define uprint_val_decs(v)          uprintf(#v ": %d\n", v)
+#define uprint_val_hex8(v)          uprintf(#v ": %X\n", v)
+#define uprint_val_hex16(v)         uprintf(#v ": %02X\n", v)
+#define uprint_val_hex32(v)         uprintf(#v ": %04lX\n", v)
+#define uprint_val_bin8(v)          uprintf(#v ": %08b\n", v)
+#define uprint_val_bin16(v)         uprintf(#v ": %016b\n", v)
+#define uprint_val_bin32(v)         uprintf(#v ": %032lb\n", v)
+#define uprint_val_bin_reverse8(v)  uprintf(#v ": %08b\n", bitrev(v))
+#define uprint_val_bin_reverse16(v) uprintf(#v ": %016b\n", bitrev16(v))
+#define uprint_val_bin_reverse32(v) uprintf(#v ": %032lb\n", bitrev32(v))
 
 #else   /* NO_PRINT */
 
@@ -142,6 +275,5 @@ void print_set_sendchar(int8_t (*print_sendchar_func)(uint8_t));
 #define pbin16(data)            print_bin16(data)
 #define pbin_reverse(data)      print_bin_reverse8(data)
 #define pbin_reverse16(data)    print_bin_reverse16(data)
-
 
 #endif


### PR DESCRIPTION
User print disables the normal print messages in the body of QMK/TMK code and is meant as a lightweight alternative to NOPRINT. Use it when
you only want to do a spot of debugging but lack flash resources for allowing all of the codebase to print (and store their wasteful
strings).
